### PR TITLE
Stop auto-assigning issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,7 +3,7 @@ name: Bug report
 about: Create a report to help us improve
 title: ''
 labels: bug
-assignees: DerekRoberts
+assignees: ''
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -3,7 +3,7 @@ name: Feature request
 about: Suggest an idea for this project
 title: ''
 labels: enhancement
-assignees: DerekRoberts
+assignees: ''
 
 ---
 


### PR DESCRIPTION
Initially pretty handy, auto-assignment breaks the current project rules.  Assigning should only happen when moving an issue to In Progress.