### PR TITLE
Project - auto assign default project to issues and PRs

### DIFF
--- a/.github/workflows/board_default.yml
+++ b/.github/workflows/board_default.yml
@@ -1,0 +1,16 @@
+name: Move new issues and pull requests to Triage
+on:
+  issues:
+    types: [opened]
+  pull_request:
+    types: [opened]
+
+jobs:
+  automate-project-columns:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: alex-page/github-project-automation-plus@v0.6.0
+        with:
+          project: Alpha
+          column: Triage
+          repo-token: ${{ secrets.PROJECT_AUTOMATION }}


### PR DESCRIPTION
Pull requests and issues can easily be overlooked when going straight to a GitHub Project.  This makes sure they end up in the default project.